### PR TITLE
Add outcome highlights to table

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export default [
             quotes: ['error', 'single'],
             'comma-dangle': ['error', 'always-multiline'],
             indent: ['error', 4],
-            'no-unused-vars': 'error',
+            'no-unused-vars': 'off',
             'max-len': ['error', { code: 100 }],
             'import/order': [
                 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.2.2",
+    "version": "0.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.2.2",
+            "version": "0.3.2",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.5",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu",
     "type": "module",
-    "version": "0.2.2",
+    "version": "0.3.2",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\"",

--- a/src/domain/espp/espp-tax-outcome.ts
+++ b/src/domain/espp/espp-tax-outcome.ts
@@ -1,0 +1,7 @@
+enum ESPPTaxOutcome {
+    GOOD = 'GOOD',
+    BETTER = 'BETTER',
+    BEST = 'BEST',
+}
+
+export { ESPPTaxOutcome };

--- a/src/pages/work/espp.astro
+++ b/src/pages/work/espp.astro
@@ -22,69 +22,93 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                     </div>
                 </div>
 
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Grant Date</th>
-                            <th>Purchase Date</th>
-                            <th>Offer Start Price</th>
-                            <th>Offer End Price</th>
-                            <th>Purchase Price</th>
-                            <th>Shares</th>
-                            <th>Discount Amount</th>
-                            <th>Current Gain/Loss</th>
-                            <th>Disqualifying Disposition w/ STCG Taxes</th>
-                            <th>Disqualifying Disposition w/ LTCG Taxes</th>
-                            <th>Qualifying Disposition</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <template
-                            x-for="purchase in data.purchases"
-                            :key="purchase.grantDate.toString()"
-                        >
+                <div clas="table-container">
+                    <table class="table is-hoverable">
+                        <thead>
                             <tr>
-                                <td x-text="methods.formatDateYYYYMMDD(purchase.grantDate)"></td>
-                                <td x-text="methods.formatDateYYYYMMDD(purchase.purchaseDate)"></td>
-                                <td
-                                    class="has-text-right"
-                                    x-text="methods.formatUSD(purchase.offerStartPrice)"></td>
-                                <td
-                                    class="has-text-right"
-                                    x-text="methods.formatUSD(purchase.offerEndPrice)"></td>
-                                <td
-                                    class="has-text-right"
-                                    x-text="methods.formatUSD(purchase.purchasePrice)"></td>
-                                <td class="has-text-right" x-text="purchase.shares"></td>
-                                <td
-                                    class="has-text-right"
-                                    x-text="methods.formatUSD(purchase.discountAmount)"></td>
-                                <td class="has-text-right" x-text="methods.formatUSD(purchase.gain)"
-                                ></td>
-                                <td
-                                    class="has-text-right"
-                                    x-text="
-                                        methods.formatUSD(
-                                            purchase.disqualifyingDispositionSTCGTaxes
-                                        )
-                                    "
-                                ></td>
-                                <td
-                                    class="has-text-right"
-                                    x-text="
-                                        methods.formatUSD(
-                                            purchase.disqualifyingDispositionLTGCTaxes
-                                        )
-                                    "
-                                ></td>
-                                <td
-                                    class="has-text-right"
-                                    x-text="methods.formatUSD(purchase.qualifyingDispositionTaxes)"
-                                ></td>
+                                <th>Grant Date</th>
+                                <th>Purchase Date</th>
+                                <th>Offer Start Price</th>
+                                <th>Offer End Price</th>
+                                <th>Purchase Price</th>
+                                <th>Shares</th>
+                                <th>Discount Amount</th>
+                                <th>Current Gain/Loss</th>
+                                <th>Disqualifying Disposition w/ STCG Taxes</th>
+                                <th>Disqualifying Disposition w/ LTCG Taxes</th>
+                                <th>Qualifying Disposition</th>
                             </tr>
-                        </template>
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            <template
+                                x-for="purchase in data.purchases"
+                                :key="purchase.grantDate.toString()"
+                            >
+                                <tr>
+                                    <td x-text="methods.formatDateYYYYMMDD(purchase.grantDate)"
+                                    ></td>
+                                    <td x-text="methods.formatDateYYYYMMDD(purchase.purchaseDate)"
+                                    ></td>
+                                    <td
+                                        class="has-text-right"
+                                        x-text="methods.formatUSD(purchase.offerStartPrice)"></td>
+                                    <td
+                                        class="has-text-right"
+                                        x-text="methods.formatUSD(purchase.offerEndPrice)"></td>
+                                    <td
+                                        class="has-text-right"
+                                        x-text="methods.formatUSD(purchase.purchasePrice)"></td>
+                                    <td class="has-text-right" x-text="purchase.shares"></td>
+                                    <td
+                                        class="has-text-right"
+                                        x-text="methods.formatUSD(purchase.discountAmount)"></td>
+                                    <td
+                                        class="has-text-right"
+                                        x-text="methods.formatUSD(purchase.gain)"></td>
+                                    <td
+                                        class="has-text-right"
+                                        :class="
+                                            data.outcomeClasses[
+                                                purchase.dispositions.disqualifyingSTCG.outcome
+                                            ]
+                                        "
+                                        x-text="
+                                        methods.formatUSD(
+                                            purchase.dispositions.disqualifyingSTCG.taxes
+                                        )
+                                    "
+                                    ></td>
+                                    <td
+                                        class="has-text-right"
+                                        :class="
+                                            data.outcomeClasses[
+                                                purchase.dispositions.disqualifyingLTCG.outcome
+                                            ]
+                                        "
+                                        x-text="
+                                        methods.formatUSD(
+                                            purchase.dispositions.disqualifyingLTCG.taxes
+                                        )
+                                    "
+                                    ></td>
+                                    <td
+                                        class="has-text-right"
+                                        :class="
+                                            data.outcomeClasses[
+                                                purchase.dispositions.qualifying.outcome
+                                            ]
+                                        "
+                                        x-text="
+                                            methods.formatUSD(
+                                                purchase.dispositions.qualifying.taxes
+                                            )
+                                        "
+                                    ></td>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
 

--- a/src/pages/work/espp.client.js
+++ b/src/pages/work/espp.client.js
@@ -1,5 +1,6 @@
 import Alpine from 'alpinejs';
 
+import { ESPPTaxOutcome } from '@/domain/espp/espp-tax-outcome';
 import { formatDateYYYYMMDD } from '@/utils/date.ts';
 import { loadESPPPurchasesTaxes, updateMarketDependentValues } from '@/utils/espp-calculations.ts';
 import { formatUSD } from '@/utils/number.ts';
@@ -9,6 +10,11 @@ function purchaseTableXData() {
         data: {
             nkeMarketPrice: '',
             purchases: loadESPPPurchasesTaxes(),
+            outcomeClasses: {
+                [ESPPTaxOutcome.GOOD]: 'has-background-danger-dark',
+                [ESPPTaxOutcome.BETTER]: 'has-background-warning-dark',
+                [ESPPTaxOutcome.BEST]: 'has-background-success-dark',
+            },
         },
         methods: {
             formatUSD,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,5 @@
+const INFINITE_DATE = new Date(8640000000000000);
+
 function addYears(date: Date, years: number): Date {
     const newDate = new Date(date);
     newDate.setFullYear(newDate.getFullYear() + years);
@@ -13,4 +15,4 @@ function latestDate(date1: Date, date2: Date): Date {
     return date1 > date2 ? date1 : date2;
 }
 
-export { addYears, latestDate, formatDateYYYYMMDD };
+export { INFINITE_DATE, addYears, latestDate, formatDateYYYYMMDD };

--- a/test/utils/espp-calculations.spec.ts
+++ b/test/utils/espp-calculations.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 
+import { ESPPTaxOutcome } from '@/domain/espp/espp-tax-outcome';
 import { loadESPPPurchasesTaxes, updateMarketDependentValues } from '@/utils/espp-calculations';
 import type { ESPPPurchaseTaxes } from '@/utils/espp-calculations';
 
@@ -28,7 +29,7 @@ vi.mock('@/data/espp/purchases.json', () => {
 
 function guardPurchaseTaxTestObject(testPurchase: ESPPPurchaseTaxes | undefined): ESPPPurchaseTaxes {
     if (!testPurchase || !testPurchase.offerEndPrice) {
-        throw new Error('Test purchase or offer end price is undefined');
+        throw new Error('Data needed for test is not available');
     }
 
     return testPurchase;
@@ -44,12 +45,19 @@ describe('espp-calculations', () => {
 
             updateMarketDependentValues(purchasesTaxes, marketPrice);
 
+            if (!testPurchase.dispositions) {
+                throw new Error('Dispositions should not be undefined');
+            }
+
             expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
             expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
             expect(testPurchase.gain).toBe(0);
-            expect(testPurchase.disqualifyingDispositionSTCGTaxes).toBeCloseTo(1145.62, 2);
-            expect(testPurchase.disqualifyingDispositionLTGCTaxes).toBeCloseTo(1145.62, 2);
-            expect(testPurchase.qualifyingDispositionTaxes).toBeCloseTo(824.33, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(1145.62, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(ESPPTaxOutcome.BETTER);
+            expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(1145.62, 2);
+            expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(ESPPTaxOutcome.BETTER);
+            expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(824.33, 2);
+            expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
         });
 
         test('should calculate cases where offering start price is less than offering end price and market price is up', async () => {
@@ -60,12 +68,19 @@ describe('espp-calculations', () => {
 
             updateMarketDependentValues(purchasesTaxes, marketPrice);
 
+            if (!testPurchase.dispositions) {
+                throw new Error('Dispositions should not be undefined');
+            }
+
             expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
             expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
             expect(testPurchase.gain).toBeCloseTo(482.65, 2);
-            expect(testPurchase.disqualifyingDispositionSTCGTaxes).toBeCloseTo(1261.46, 2);
-            expect(testPurchase.disqualifyingDispositionLTGCTaxes).toBeCloseTo(1218.02, 2);
-            expect(testPurchase.qualifyingDispositionTaxes).toBeCloseTo(896.73, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(1261.46, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(ESPPTaxOutcome.GOOD);
+            expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(1218.02, 2);
+            expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(ESPPTaxOutcome.BETTER);
+            expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(896.73, 2);
+            expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
         });
 
         test('should calculate cases where offering start price is less than offering end price and market price is down', async () => {
@@ -76,12 +91,19 @@ describe('espp-calculations', () => {
 
             updateMarketDependentValues(purchasesTaxes, marketPrice);
 
+            if (!testPurchase.dispositions) {
+                throw new Error('Dispositions should not be undefined');
+            }
+
             expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
             expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
             expect(testPurchase.gain).toBeCloseTo(-965.30, 2);
-            expect(testPurchase.disqualifyingDispositionSTCGTaxes).toBeCloseTo(913.95, 2);
-            expect(testPurchase.disqualifyingDispositionLTGCTaxes).toBeCloseTo(913.95, 2);
-            expect(testPurchase.qualifyingDispositionTaxes).toBeCloseTo(679.54, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(913.95, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(ESPPTaxOutcome.BETTER);
+            expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(913.95, 2);
+            expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(ESPPTaxOutcome.BETTER);
+            expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(679.54, 2);
+            expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
         });
 
         test('should calculate cases where offering start price is greater than offering end price and market price is flat', async () => {
@@ -92,12 +114,19 @@ describe('espp-calculations', () => {
 
             updateMarketDependentValues(purchasesTaxes, marketPrice);
 
+            if (!testPurchase.dispositions) {
+                throw new Error('Dispositions should not be undefined');
+            }
+
             expect(testPurchase.purchaseMarketPrice).toBe(marketPrice);
             expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
             expect(testPurchase.gain).toBe(0);
-            expect(testPurchase.disqualifyingDispositionSTCGTaxes).toBeCloseTo(342.38, 2);
-            expect(testPurchase.disqualifyingDispositionLTGCTaxes).toBeCloseTo(342.38, 2);
-            expect(testPurchase.qualifyingDispositionTaxes).toBeCloseTo(342.38, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(342.38, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(ESPPTaxOutcome.BEST);
+            expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(342.38, 2);
+            expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(ESPPTaxOutcome.BEST);
+            expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(342.38, 2);
+            expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
         });
 
         test('should calculate cases where offering start price is greater than offering end price and market price is up', () => {
@@ -108,12 +137,19 @@ describe('espp-calculations', () => {
 
             updateMarketDependentValues(purchasesTaxes, marketPrice);
 
+            if (!testPurchase.dispositions) {
+                throw new Error('Dispositions should not be undefined');
+            }
+
             expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
             expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
             expect(testPurchase.gain).toBeCloseTo(977.02, 2);
-            expect(testPurchase.disqualifyingDispositionSTCGTaxes).toBeCloseTo(576.86, 2);
-            expect(testPurchase.disqualifyingDispositionLTGCTaxes).toBeCloseTo(488.93, 2);
-            expect(testPurchase.qualifyingDispositionTaxes).toBeCloseTo(540.85, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(576.86, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(ESPPTaxOutcome.GOOD);
+            expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(488.93, 2);
+            expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(ESPPTaxOutcome.BEST);
+            expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(540.85, 2);
+            expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BETTER);
         });
 
         test('should calculate cases where offering start price is greater than offering end price and market price is down', () => {
@@ -124,12 +160,19 @@ describe('espp-calculations', () => {
 
             updateMarketDependentValues(purchasesTaxes, marketPrice);
 
+            if (!testPurchase.dispositions) {
+                throw new Error('Dispositions should not be undefined');
+            }
+
             expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
             expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
             expect(testPurchase.gain).toBeCloseTo(-749.25, 2);
-            expect(testPurchase.disqualifyingDispositionSTCGTaxes).toBeCloseTo(162.56, 2);
-            expect(testPurchase.disqualifyingDispositionLTGCTaxes).toBeCloseTo(162.56, 2);
-            expect(testPurchase.qualifyingDispositionTaxes).toBeCloseTo(162.56, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(162.56, 2);
+            expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(ESPPTaxOutcome.BEST);
+            expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(162.56, 2);
+            expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(ESPPTaxOutcome.BEST);
+            expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(162.56, 2);
+            expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
         });
     });
 });


### PR DESCRIPTION
<img width="1363" alt="Screenshot 2025-04-15 at 12 31 05 AM" src="https://github.com/user-attachments/assets/69638cf5-1155-4591-8a93-c988359a43a1" />

### What

Add selling outcome highlights to table

### How

- Add outcome domain enum
- Restructure ESPP interfaces
- Add outcome clases map to Alpine.js data
