### PR TITLE
Improve ESPP page style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.5",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu",
     "type": "module",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\"",

--- a/src/domain/espp/espp-purchase-raw.ts
+++ b/src/domain/espp/espp-purchase-raw.ts
@@ -1,0 +1,20 @@
+interface ESPPPurchaseRaw {
+    grantDate: string;
+    purchaseDate: string;
+    offerStartPrice: string;
+    offerEndPrice: string;
+    purchasePrice: string;
+    shares: string;
+}
+
+const ESPP_PURCHASE_REQUIRED_FIELDS = [
+    'grantDate',
+    'purchaseDate',
+    'offerStartPrice',
+    'offerEndPrice',
+    'purchasePrice',
+    'shares',
+] as const satisfies ReadonlyArray<keyof ESPPPurchaseRaw>;
+
+export { ESPP_PURCHASE_REQUIRED_FIELDS };
+export type { ESPPPurchaseRaw };

--- a/src/pages/work/espp.astro
+++ b/src/pages/work/espp.astro
@@ -7,114 +7,158 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
     <section class="section">
         <div class="container">
             <h1 class="title is-1">ESPP</h1>
-            <h2 class="title is-2">Tax Considerations</h2>
+        </div>
+    </section>
 
+    <section class="section">
+        <div class="container">
             <div x-data="purchaseTableXData()" @upload="methods.onFileUpload">
-                <FileUpload />
+                <div class="block">
+                    <div class="box">
+                        <h2 class="title is-2">Upload Your ESPP Purchases</h2>
+                        <div class="block">
+                            <FileUpload />
+                        </div>
 
-                <div class="field">
-                    <label class="label">NKE Market Price</label>
-                    <div class="control">
-                        <input
-                            class="input"
-                            type="text"
-                            placeholder="Enter NKE Market Price"
-                            x-model="data.nkeMarketPrice"
-                            @input="methods.onMarketPriceInput"
-                        />
+                        <div class="block">
+                            <article class="message is-info">
+                                <div class="message-body">
+                                    Upload a CSV with these fields: <span
+                                        x-text="methods.displayRequiredFields"></span>
+                                </div>
+                            </article>
+                        </div>
                     </div>
                 </div>
 
-                <div clas="table-container">
-                    <table class="table is-hoverable">
-                        <thead>
-                            <tr>
-                                <th>Grant Date</th>
-                                <th>Purchase Date</th>
-                                <th>Offer Start Price</th>
-                                <th>Offer End Price</th>
-                                <th>Purchase Price</th>
-                                <th>Shares</th>
-                                <th>Discount Amount</th>
-                                <th>Current Gain/Loss</th>
-                                <th>Disqualifying Disposition w/ STCG Taxes</th>
-                                <th>Disqualifying Disposition w/ LTCG Taxes</th>
-                                <th>Qualifying Disposition</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <template
-                                x-for="purchase in data.purchases"
-                                :key="purchase.grantDate.toString()"
-                            >
-                                <tr>
-                                    <td x-text="methods.formatDateYYYYMMDD(purchase.grantDate)"
-                                    ></td>
-                                    <td x-text="methods.formatDateYYYYMMDD(purchase.purchaseDate)"
-                                    ></td>
-                                    <td
-                                        class="has-text-right"
-                                        x-text="methods.formatUSD(purchase.offerStartPrice)"></td>
-                                    <td
-                                        class="has-text-right"
-                                        x-text="methods.formatUSD(purchase.offerEndPrice)"></td>
-                                    <td
-                                        class="has-text-right"
-                                        x-text="methods.formatUSD(purchase.purchasePrice)"></td>
-                                    <td class="has-text-right" x-text="purchase.shares"></td>
-                                    <td
-                                        class="has-text-right"
-                                        x-text="methods.formatUSD(purchase.discountAmount)"></td>
-                                    <td
-                                        class="has-text-right"
-                                        x-text="methods.formatUSD(purchase.gain)"></td>
-                                    <td
-                                        class="has-text-right"
-                                        :class="
+                <div class="block" x-show="methods.showTaxConsiderations" x-transition>
+                    <div class="box">
+                        <h2 class="title is-2">Tax Consideration Parameters</h2>
+                        <div class="columns">
+                            <div class="column is-4">
+                                <div class="field">
+                                    <label class="label">NKE Market Price</label>
+                                    <div class="control">
+                                        <input
+                                            class="input"
+                                            type="number"
+                                            placeholder="Enter NKE Market Price"
+                                            x-model="data.nkeMarketPrice"
+                                            @input="methods.onMarketPriceInput"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="block" x-show="methods.showTaxConsiderations" x-transition>
+                    <div class="box">
+                        <h2 class="title is-2">Tax Consideration Results</h2>
+                        <div class="table-container">
+                            <table class="table is-hoverable">
+                                <thead>
+                                    <tr>
+                                        <th>Grant Date</th>
+                                        <th>Purchase Date</th>
+                                        <th>Offer Start Price</th>
+                                        <th>Offer End Price</th>
+                                        <th>Purchase Price</th>
+                                        <th>Shares</th>
+                                        <th>Discount Amount</th>
+                                        <th>Current Gain/Loss</th>
+                                        <th>Disqualifying Disposition w/ STCG Taxes</th>
+                                        <th>Disqualifying Disposition w/ LTCG Taxes</th>
+                                        <th>Qualifying Disposition</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <template
+                                        x-for="purchase in data.purchases"
+                                        :key="purchase.grantDate.toString()"
+                                    >
+                                        <tr>
+                                            <td
+                                                x-text="
+                                                    methods.formatDateYYYYMMDD(purchase.grantDate)
+                                                "
+                                            ></td>
+                                            <td
+                                                x-text="
+                                                methods.formatDateYYYYMMDD(purchase.purchaseDate)
+                                            "
+                                            ></td>
+                                            <td
+                                                class="has-text-right"
+                                                x-text="methods.formatUSD(purchase.offerStartPrice)"
+                                            ></td>
+                                            <td
+                                                class="has-text-right"
+                                                x-text="methods.formatUSD(purchase.offerEndPrice)"
+                                            ></td>
+                                            <td
+                                                class="has-text-right"
+                                                x-text="methods.formatUSD(purchase.purchasePrice)"
+                                            ></td>
+                                            <td class="has-text-right" x-text="purchase.shares"
+                                            ></td>
+                                            <td
+                                                class="has-text-right"
+                                                x-text="methods.formatUSD(purchase.discountAmount)"
+                                            ></td>
+                                            <td
+                                                class="has-text-right"
+                                                x-text="methods.formatUSD(purchase.gain)"></td>
+                                            <td
+                                                class="has-text-right"
+                                                :class="
                                             data.outcomeClasses[
                                                 purchase.dispositions?.disqualifyingSTCG.outcome
                                             ]
                                         "
-                                        x-text="
+                                                x-text="
                                         methods.formatUSD(
                                             purchase.dispositions?.disqualifyingSTCG.taxes
                                         )
                                     "
-                                    ></td>
-                                    <td
-                                        class="has-text-right"
-                                        :class="
+                                            ></td>
+                                            <td
+                                                class="has-text-right"
+                                                :class="
                                             data.outcomeClasses[
                                                 purchase.dispositions?.disqualifyingLTCG.outcome
                                             ]
                                         "
-                                        x-text="
+                                                x-text="
                                         methods.formatUSD(
                                             purchase.dispositions?.disqualifyingLTCG.taxes
                                         )
                                     "
-                                    ></td>
-                                    <td
-                                        class="has-text-right"
-                                        :class="
+                                            ></td>
+                                            <td
+                                                class="has-text-right"
+                                                :class="
                                             data.outcomeClasses[
                                                 purchase.dispositions?.qualifying.outcome
                                             ]
                                         "
-                                        x-text="
+                                                x-text="
                                             methods.formatUSD(
                                                 purchase.dispositions?.qualifying.taxes
                                             )
                                         "
-                                    ></td>
-                                </tr>
-                            </template>
-                        </tbody>
-                    </table>
+                                            ></td>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-
-        <script src="./espp.client.ts"></script>
     </section>
 </BaseLayout>
+
+<script src="./espp.client.ts"></script>

--- a/src/pages/work/espp.client.ts
+++ b/src/pages/work/espp.client.ts
@@ -1,13 +1,19 @@
 import Alpine from 'alpinejs';
 
 import type { XData } from '@/domain/components/x-data';
+import { ESPP_PURCHASE_REQUIRED_FIELDS } from '@/domain/espp/espp-purchase-raw';
 import { ESPPTaxOutcome } from '@/domain/espp/espp-tax-outcome';
 import { csvToJson } from '@/utils/data';
 import { formatDateYYYYMMDD } from '@/utils/date';
-import { loadESPPPurchasesTaxes, updateMarketDependentValues } from '@/utils/espp-calculations';
+import {
+    loadESPPPurchasesTaxes,
+    updateMarketDependentValues,
+    clearMarketDependentValues,
+} from '@/utils/espp-calculations';
 import type { ESPPPurchaseRaw, ESPPPurchaseTaxes } from '@/utils/espp-calculations';
 import { read } from '@/utils/file';
 import { formatUSD } from '@/utils/number';
+import { arrayToCommaSeparatedString } from '@/utils/string';
 
 type PurchaseTableXData = XData<
     {
@@ -18,8 +24,10 @@ type PurchaseTableXData = XData<
     {
         formatUSD: typeof formatUSD;
         formatDateYYYYMMDD: typeof formatDateYYYYMMDD;
+        showTaxConsiderations: () => boolean;
         onFileUpload: (event: CustomEvent) => void;
         onMarketPriceInput: () => void;
+        displayRequiredFields: () => string;
     }
 >;
 
@@ -37,6 +45,9 @@ function purchaseTableXData(): PurchaseTableXData {
         methods: {
             formatUSD,
             formatDateYYYYMMDD,
+            showTaxConsiderations(this: PurchaseTableXData): boolean {
+                return this.data.purchases.length > 0;
+            },
             async onFileUpload(this: PurchaseTableXData, event: CustomEvent): Promise<void> {
                 if (!event.detail) {
                     return;
@@ -52,12 +63,16 @@ function purchaseTableXData(): PurchaseTableXData {
                 console.log('Market Price:', marketPrice);
 
                 if (isNaN(marketPrice)) {
+                    clearMarketDependentValues(this.data.purchases);
                     return;
                 }
 
                 updateMarketDependentValues(this.data.purchases, marketPrice);
 
                 console.log('Purchases:', this.data.purchases);
+            },
+            displayRequiredFields(): string {
+                return arrayToCommaSeparatedString(ESPP_PURCHASE_REQUIRED_FIELDS);
             },
         },
     };

--- a/src/utils/espp-calculations.ts
+++ b/src/utils/espp-calculations.ts
@@ -1,18 +1,10 @@
+import type { ESPPPurchaseRaw } from '@/domain/espp/espp-purchase-raw';
 import { ESPPTaxOutcome } from '@/domain/espp/espp-tax-outcome';
 import { INFINITE_DATE, addYears, latestDate } from '@/utils/date';
 
 const ESPP_DISCOUNT = 0.15;
 const ORDINARY_INCOME_TAX_RATE = 0.24;
 const LONG_TERM_CAPITAL_GAINS_TAX_RATE = 0.15;
-
-interface ESPPPurchaseRaw {
-    grantDate: string;
-    purchaseDate: string;
-    offerStartPrice: string;
-    offerEndPrice: string;
-    purchasePrice: string;
-    shares: string;
-}
 
 interface ESPPPurchase {
     grantDate: Date;
@@ -72,7 +64,14 @@ function updateMarketDependentValues(purchases: ESPPPurchaseTaxes[], marketPrice
     });
 }
 
-export { loadESPPPurchasesTaxes, updateMarketDependentValues };
+function clearMarketDependentValues(purchases: ESPPPurchaseTaxes[]): void {
+    purchases.forEach((purchase) => {
+        delete purchase.gain;
+        delete purchase.dispositions;
+    });
+}
+
+export { loadESPPPurchasesTaxes, updateMarketDependentValues, clearMarketDependentValues };
 export type { ESPPPurchaseRaw, ESPPPurchaseTaxes };
 
 function _loadESPPPurchases(esppPurchasesRaw: ESPPPurchaseRaw[]): ESPPPurchase[] {

--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -1,0 +1,5 @@
+function createFieldList<T>(fields: readonly (keyof T)[]): typeof fields {
+    return fields;
+}
+
+export { createFieldList };

--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -1,5 +1,0 @@
-function createFieldList<T>(fields: readonly (keyof T)[]): typeof fields {
-    return fields;
-}
-
-export { createFieldList };

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,5 @@
+function arrayToCommaSeparatedString(arr: ReadonlyArray<string>): string {
+    return arr.join(', ');
+}
+
+export { arrayToCommaSeparatedString };


### PR DESCRIPTION
<img width="1399" alt="Screenshot 2025-04-17 at 10 42 19 PM" src="https://github.com/user-attachments/assets/af0121d2-6b43-4a70-9c96-ef16a4e57bff" />

### What

Improve ESPP page style and interactivity

### How

- Space page sections
- Only show page sections when data is loaded
- Add required CSV fields to info message
- Add clear fields on empty market price
