### PR TITLE
Add loading states for ESPP Lots

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.11.0",
+            "version": "0.11.1",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.7",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu",
     "type": "module",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",

--- a/frontend/src/pages/work/espp.astro
+++ b/frontend/src/pages/work/espp.astro
@@ -180,85 +180,128 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                     </tr>
                                 </thead>
                                 <tbody>
+                                    <template x-if="data.isLoadingESPPLots">
+                                        <tr>
+                                            <td colspan="11">
+                                                <progress class="progress is-primary">
+                                                    Loading...
+                                                </progress>
+                                            </td>
+                                        </tr>
+                                    </template>
                                     <template
-                                        x-for="purchase in methods.sortArrayOfObjectsByKey(
-                                            data.purchases,
-                                            'grantDate'
-                                        )"
-                                        :key="purchase.grantDate.toString()"
+                                        x-if="
+                                            !data.isLoadingESPPLots && data.purchases.length === 0
+                                        "
                                     >
                                         <tr>
-                                            <td
-                                                x-text="
-                                                    methods.formatDateYYYYMMDD(purchase.grantDate)
-                                                "
-                                            ></td>
-                                            <td
-                                                x-text="
-                                                methods.formatDateYYYYMMDD(purchase.purchaseDate)
-                                            "
-                                            ></td>
-                                            <td
-                                                class="has-text-right"
-                                                x-text="methods.formatUSD(purchase.offerStartPrice)"
-                                            ></td>
-                                            <td
-                                                class="has-text-right"
-                                                x-text="methods.formatUSD(purchase.offerEndPrice)"
-                                            ></td>
-                                            <td
-                                                class="has-text-right"
-                                                x-text="methods.formatUSD(purchase.purchasePrice)"
-                                            ></td>
-                                            <td class="has-text-right" x-text="purchase.shares"
-                                            ></td>
-                                            <td
-                                                class="has-text-right"
-                                                x-text="methods.formatUSD(purchase.discountAmount)"
-                                            ></td>
-                                            <td
-                                                class="has-text-right"
-                                                x-text="methods.formatUSD(purchase.gain)"></td>
-                                            <td
-                                                class="has-text-right"
-                                                :class="
-                                            data.outcomeClasses[
-                                                purchase.dispositions?.disqualifyingSTCG.outcome
-                                            ]
-                                        "
-                                                x-text="
-                                        methods.formatUSD(
-                                            purchase.dispositions?.disqualifyingSTCG.taxes
-                                        )
-                                    "
-                                            ></td>
-                                            <td
-                                                class="has-text-right"
-                                                :class="
-                                            data.outcomeClasses[
-                                                purchase.dispositions?.disqualifyingLTCG.outcome
-                                            ]
-                                        "
-                                                x-text="
-                                        methods.formatUSD(
-                                            purchase.dispositions?.disqualifyingLTCG.taxes
-                                        )
-                                    "
-                                            ></td>
-                                            <td
-                                                class="has-text-right"
-                                                :class="
-                                            data.outcomeClasses[
-                                                purchase.dispositions?.qualifying.outcome
-                                            ]
-                                        "
-                                                x-text="
-                                            methods.formatUSD(
-                                                purchase.dispositions?.qualifying.taxes
-                                            )
-                                        "
-                                            ></td>
+                                            <td colspan="11">
+                                                <div class="has-text-centered">
+                                                    No ESPP purchases found.
+                                                </div>
+                                            </td>
                                         </tr>
+                                    </template>
+                                    <template
+                                        x-if="
+                                            !data.isLoadingESPPLots && data.purchases.length !== 0
+                                        "
+                                    >
+                                        <template
+                                            x-for="purchase in methods.sortArrayOfObjectsByKey(
+                                                    data.purchases,
+                                                    'grantDate'
+                                                )"
+                                            :key="purchase.grantDate.toString()"
+                                        >
+                                            <tr>
+                                                <td
+                                                    x-text="
+                                                        methods.formatDateYYYYMMDD(
+                                                            purchase.grantDate
+                                                        )
+                                                    "
+                                                ></td>
+                                                <td
+                                                    x-text="
+                                                        methods.formatDateYYYYMMDD(
+                                                            purchase.purchaseDate
+                                                        )
+                                                    "
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    x-text="
+                                                        methods.formatUSD(purchase.offerStartPrice)
+                                                    "
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    x-text="
+                                                        methods.formatUSD(purchase.offerEndPrice)
+                                                    "
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    x-text="
+                                                        methods.formatUSD(purchase.purchasePrice)
+                                                    "
+                                                ></td>
+                                                <td class="has-text-right" x-text="purchase.shares"
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    x-text="
+                                                        methods.formatUSD(purchase.discountAmount)
+                                                    "
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    x-text="
+                                                        methods.formatUSD(purchase.gain)
+                                                    "
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    :class="
+                                                data.outcomeClasses[
+                                                    purchase.dispositions?.disqualifyingSTCG.outcome
+                                                ]
+                                            "
+                                                    x-text="
+                                                methods.formatUSD(
+                                                    purchase.dispositions?.disqualifyingSTCG.taxes
+                                                )
+                                            "
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    :class="
+                                                data.outcomeClasses[
+                                                    purchase.dispositions?.disqualifyingLTCG.outcome
+                                                ]
+                                            "
+                                                    x-text="
+                                                methods.formatUSD(
+                                                    purchase.dispositions?.disqualifyingLTCG.taxes
+                                                )
+                                            "
+                                                ></td>
+                                                <td
+                                                    class="has-text-right"
+                                                    :class="
+                                                    data.outcomeClasses[
+                                                        purchase.dispositions?.qualifying.outcome
+                                                    ]
+                                                "
+                                                    x-text="
+                                                    methods.formatUSD(
+                                                        purchase.dispositions?.qualifying.taxes
+                                                    )
+                                                "
+                                                ></td>
+                                            </tr>
+                                        </template>
                                     </template>
                                 </tbody>
                             </table>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5b28c80e-2fa4-4f58-95c9-e393de881459)

### What

Add loading and no data states for ESPP purchases

### How

- Show table when logged in

### Validation

- Unit test coverage 63%