### PR TITLE
ESPP Table UI fixes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.12.0",
+            "version": "0.12.1",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.7",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu",
     "type": "module",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",

--- a/frontend/src/pages/work/_espp.client.ts
+++ b/frontend/src/pages/work/_espp.client.ts
@@ -11,7 +11,7 @@ import {
 } from '@/domain/espp/espp-purchase-raw';
 import { ESPPTaxOutcome } from '@/domain/espp/espp-tax-outcome';
 import { register } from '@/utils/alpine-components';
-import { sortArrayOfObjectsByKey } from '@/utils/array';
+import { sortArrayOfObjectsByKey, isLastElement } from '@/utils/array';
 import { getCurrentUser } from '@/utils/auth';
 import { csvToJson } from '@/utils/data';
 import { formatDateYYYYMMDD } from '@/utils/date';
@@ -50,6 +50,7 @@ type PurchaseTableXData = XData<
         formatUSD: typeof formatUSD;
         formatDateYYYYMMDD: typeof formatDateYYYYMMDD;
         sortArrayOfObjectsByKey: typeof sortArrayOfObjectsByKey;
+        isLastElement: typeof isLastElement;
         init: () => Promise<void>;
         showTaxConsiderations: () => boolean;
         onFileUpload: (event: CustomEvent) => void;
@@ -89,6 +90,7 @@ function purchaseTableXData(): PurchaseTableXData {
             formatUSD,
             formatDateYYYYMMDD,
             sortArrayOfObjectsByKey,
+            isLastElement,
             async init(this: PurchaseTableXData): Promise<void> {
                 this.data.user = await getCurrentUser();
 

--- a/frontend/src/pages/work/espp.astro
+++ b/frontend/src/pages/work/espp.astro
@@ -164,7 +164,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                         <th>Purchase Price</th>
                                         <th>Shares</th>
                                         <th>Discount Amount</th>
-                                        <th>Current Gain/Loss</th>
+                                        <th>Total Gain/Loss</th>
                                         <th>Disqualifying Disposition w/ STCG Taxes</th>
                                         <th>Disqualifying Disposition w/ LTCG Taxes</th>
                                         <th>Qualifying Disposition</th>
@@ -200,7 +200,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                         "
                                     >
                                         <template
-                                            x-for="purchase in data.purchases"
+                                            x-for="(purchase, index) in data.purchases"
                                             :key="purchase.id"
                                         >
                                             <tr>
@@ -247,7 +247,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                 <td
                                                     class="has-text-right"
                                                     x-text="
-                                                        methods.formatUSD(purchase.gain)
+                                                        methods.formatUSD(purchase.totalGain)
                                                     "
                                                 ></td>
                                                 <td
@@ -289,11 +289,16 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                     )
                                                 "
                                                 ></td>
-                                                <td>
+                                                <td class="has-text-centered is-vcentered">
                                                     <div
                                                         class="dropdown is-right"
                                                         :class="
                                                             {
+                                                                'is-up':
+                                                                    methods.isLastElement(
+                                                                        data.purchases,
+                                                                        index
+                                                                    ),
                                                                 'is-active':
                                                                     purchase.uiState.isActionsOpen
                                                             }

--- a/frontend/src/utils/array.ts
+++ b/frontend/src/utils/array.ts
@@ -10,4 +10,8 @@ function sortArrayOfObjectsByKey<T extends Record<string, unknown>>(arr: T[], ke
     });
 }
 
-export { sortArrayOfObjectsByKey };
+function isLastElement<T>(arr: T[], index: number): boolean {
+    return index === arr.length - 1;
+}
+
+export { sortArrayOfObjectsByKey, isLastElement };

--- a/frontend/test/utils/espp-calculations.spec.ts
+++ b/frontend/test/utils/espp-calculations.spec.ts
@@ -58,7 +58,7 @@ describe('espp-calculations', () => {
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
-                expect(testPurchase.gain).toBe(0);
+                expect(testPurchase.marketGain).toBe(0);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(1145.62, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BETTER,
@@ -89,7 +89,7 @@ describe('espp-calculations', () => {
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
-                expect(testPurchase.gain).toBeCloseTo(482.65, 2);
+                expect(testPurchase.marketGain).toBeCloseTo(482.65, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(1261.46, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.GOOD,
@@ -120,7 +120,7 @@ describe('espp-calculations', () => {
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
-                expect(testPurchase.gain).toBeCloseTo(-965.3, 2);
+                expect(testPurchase.marketGain).toBeCloseTo(-965.3, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(913.95, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BETTER,
@@ -151,7 +151,7 @@ describe('espp-calculations', () => {
 
                 expect(testPurchase.purchaseMarketPrice).toBe(marketPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
-                expect(testPurchase.gain).toBe(0);
+                expect(testPurchase.marketGain).toBe(0);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(342.38, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BEST,
@@ -182,7 +182,7 @@ describe('espp-calculations', () => {
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
-                expect(testPurchase.gain).toBeCloseTo(977.02, 2);
+                expect(testPurchase.marketGain).toBeCloseTo(977.02, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(576.86, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.GOOD,
@@ -213,7 +213,7 @@ describe('espp-calculations', () => {
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
-                expect(testPurchase.gain).toBeCloseTo(-749.25, 2);
+                expect(testPurchase.marketGain).toBeCloseTo(-749.25, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(162.56, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BEST,
@@ -235,12 +235,12 @@ describe('espp-calculations', () => {
 
             updateMarketDependentValues(purchasesTaxes, 100);
 
-            expect(testPurchase.gain).toBeDefined();
+            expect(testPurchase.marketGain).toBeDefined();
             expect(testPurchase.dispositions).toBeDefined();
 
             clearMarketDependentValues(purchasesTaxes);
 
-            expect(testPurchase.gain).toBeUndefined();
+            expect(testPurchase.marketGain).toBeUndefined();
             expect(testPurchase.dispositions).toBeUndefined();
         });
     });


### PR DESCRIPTION
### What

Various ESPP Table UI fixes

### How

- Make actions dropdown go up for last row to avoid cutting off
- Show total gain instead of "current" gain
  - Total gain is discount amount + market gain
  - If market price is above purchase price but below end price total gain is still positive
- Center actions dropdown horizontally and vertically

### Validation

- Unit test coverage 58%