### PR TITLE
Add details to gains and taxes cells

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.12.1",
+            "version": "0.13.0",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.7",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu",
     "type": "module",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",

--- a/frontend/src/api/resources/user.ts
+++ b/frontend/src/api/resources/user.ts
@@ -1,7 +1,7 @@
 import { API_HOST, CACHE_BASE_USER, CACHE_BASE_USER_ESPP_LOT } from '@/api/constants';
+import type { ESPPPurchaseRaw } from '@/domain/espp/espp-purchase-raw';
 import type { Settings, RawUserSettings, UserSettings } from '@/domain/user/user-settings';
 import { getCachedItem, setCachedItem, getCacheKey } from '@/utils/cache';
-import type { ESPPPurchaseRaw } from '@/utils/espp-calculations';
 
 async function get(userId: string): Promise<UserSettings> {
     const cacheKey = getCacheKey([CACHE_BASE_USER, userId]);

--- a/frontend/src/components/molecules/CellDetails/CellDetails.astro
+++ b/frontend/src/components/molecules/CellDetails/CellDetails.astro
@@ -8,7 +8,6 @@ interface Props {
 }
 
 const { lineItemsXFor, totalXText } = Astro.props;
-console.log('CellDetails props:', { lineItemsXFor, totalXText });
 ---
 
 <div

--- a/frontend/src/components/molecules/CellDetails/CellDetails.astro
+++ b/frontend/src/components/molecules/CellDetails/CellDetails.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+    lineItemsXFor: Array<{
+        label: string;
+        amount: number;
+    }>;
+    totalXText: string;
+}
+
+const { lineItemsXFor, totalXText } = Astro.props;
+console.log('CellDetails props:', { lineItemsXFor, totalXText });
+---
+
+<div
+    class="has-background-primary-dark has-text-primary-dark-invert p-2 is-size-7 has-text-right"
+    style="border-radius: 4px; white-space: nowrap;"
+>
+    <template x-for={`item in ${lineItemsXFor}`}>
+        <div>
+            <span x-text="`${item.label}:`"></span>
+            <span class="ml-2" x-text="item.amount"></span>
+        </div>
+    </template>
+    <div class="mt-2 pt-2" style="border-top: 1px dashed;">
+        <span class="has-text-weight-bold">Total:</span>
+        <span class="ml-2 has-text-weight-bold" x-text={totalXText}></span>
+    </div>
+</div>

--- a/frontend/src/pages/work/_espp.utils.ts
+++ b/frontend/src/pages/work/_espp.utils.ts
@@ -1,0 +1,169 @@
+import { ESPPTaxOutcome } from '@/domain/espp/espp-tax-outcome';
+import { sortArrayOfObjectsByKey } from '@/utils/array';
+import { formatDateYYYYMMDD } from '@/utils/date';
+import {
+    type ESPPDisposition,
+    type ESPPDispositions,
+    type ESPPPurchaseTaxes,
+    type ESPPTaxes,
+} from '@/utils/espp-calculations';
+import { formatUSD, round } from '@/utils/number';
+
+interface ESPPDetailsUI {
+    label: string;
+    amount: string;
+}
+
+interface ESSPGainsUI {
+    discountAmount: string;
+    market: string | undefined;
+    total: string | undefined;
+    details: ESPPDetailsUI[];
+}
+
+interface ESPPTaxesUI {
+    ordinaryIncome: string;
+    stcg: string;
+    ltcg: string;
+    total: string;
+    details: ESPPDetailsUI[];
+}
+
+interface ESPPDispositionUI {
+    taxes: ESPPTaxesUI;
+    outcome: ESPPTaxOutcome;
+}
+
+interface ESPPDispositionsUI {
+    disqualifyingSTCG: ESPPDispositionUI;
+    disqualifyingLTCG: ESPPDispositionUI;
+    qualifying: ESPPDispositionUI;
+}
+
+interface ESPPPurchaseUIState {
+    isDetailsOpen: boolean;
+    isActionsOpen: boolean;
+    isDeleting: boolean;
+}
+
+interface ESPPPurchaseTaxesUI {
+    id: string;
+    grantDate: string;
+    purchaseDate: string;
+    offerStartPrice: string;
+    offerEndPrice: string;
+    purchasePrice: string;
+    shares: string;
+    gains: ESSPGainsUI;
+    dispositions: ESPPDispositionsUI | undefined;
+    uiState: ESPPPurchaseUIState;
+}
+
+function convertEsppTaxesToUIState(purchasesTaxes: ESPPPurchaseTaxes[]): ESPPPurchaseTaxesUI[] {
+    const purchasesUIState = purchasesTaxes.map((purchase) => {
+        return {
+            id: purchase.id,
+            grantDate: formatDateYYYYMMDD(purchase.grantDate),
+            purchaseDate: formatDateYYYYMMDD(purchase.purchaseDate),
+            offerStartPrice: formatUSD(purchase.offerStartPrice),
+            offerEndPrice: formatUSD(purchase.offerEndPrice),
+            purchasePrice: formatUSD(purchase.purchasePrice),
+            shares: round(purchase.shares, 4).toString(),
+            gains: convertGainsToUI(purchase),
+            dispositions: purchase.dispositions
+                ? _convertDisposistionsToUI(purchase.dispositions)
+                : undefined,
+            uiState: {
+                isDetailsOpen: false,
+                isActionsOpen: false,
+                isDeleting: false,
+            },
+        };
+    });
+
+    return sortArrayOfObjectsByKey(purchasesUIState, 'grantDate');
+}
+
+export { convertEsppTaxesToUIState };
+export type { ESPPPurchaseTaxesUI };
+
+function convertGainsToUI(purchase: ESPPPurchaseTaxes): ESSPGainsUI {
+    return {
+        discountAmount: formatUSD(purchase.discountAmount),
+        market: purchase.marketGain ? formatUSD(purchase.marketGain) : undefined,
+        total: purchase.totalGain ? formatUSD(purchase.totalGain) : undefined,
+        details: _convertGainsToDetailsUI(purchase),
+    };
+}
+
+function _convertGainsToDetailsUI(purchase: ESPPPurchaseTaxes): ESPPDetailsUI[] {
+    const details: ESPPDetailsUI[] = [];
+
+    if (purchase.discountAmount) {
+        details.push({
+            label: 'Discount',
+            amount: formatUSD(purchase.discountAmount),
+        });
+    }
+
+    if (purchase.marketGain) {
+        details.push({
+            label: 'Market',
+            amount: formatUSD(purchase.marketGain),
+        });
+    }
+
+    return details;
+}
+
+function _convertDisposistionsToUI(disposistions: ESPPDispositions): ESPPDispositionsUI {
+    return {
+        disqualifyingSTCG: _convertDisposistionToUI(disposistions.disqualifyingSTCG),
+        disqualifyingLTCG: _convertDisposistionToUI(disposistions.disqualifyingLTCG),
+        qualifying: _convertDisposistionToUI(disposistions.qualifying),
+    };
+}
+
+function _convertDisposistionToUI(disposistion: ESPPDisposition): ESPPDispositionUI {
+    return {
+        taxes: _convertTaxestoUI(disposistion.taxes),
+        outcome: disposistion.outcome,
+    };
+}
+
+function _convertTaxestoUI(taxes: ESPPTaxes): ESPPTaxesUI {
+    return {
+        ordinaryIncome: formatUSD(taxes.ordinaryIncome),
+        stcg: formatUSD(taxes.stcg),
+        ltcg: formatUSD(taxes.ltcg),
+        total: formatUSD(taxes.total),
+        details: _convertTaxestoDetailsUI(taxes),
+    };
+}
+
+function _convertTaxestoDetailsUI(taxes: ESPPTaxes): ESPPDetailsUI[] {
+    const details: ESPPDetailsUI[] = [];
+
+    if (taxes.ordinaryIncome) {
+        details.push({
+            label: 'Ordinary Income',
+            amount: formatUSD(taxes.ordinaryIncome),
+        });
+    }
+
+    if (taxes.stcg) {
+        details.push({
+            label: 'STCG',
+            amount: formatUSD(taxes.stcg),
+        });
+    }
+
+    if (taxes.ltcg) {
+        details.push({
+            label: 'LTCG',
+            amount: formatUSD(taxes.ltcg),
+        });
+    }
+
+    return details;
+}

--- a/frontend/src/pages/work/espp.astro
+++ b/frontend/src/pages/work/espp.astro
@@ -1,4 +1,5 @@
 ---
+import CellDetails from '@/components/molecules/CellDetails/CellDetails.astro';
 import DateInput from '@/components/molecules/DateInput/DateInput.astro';
 import FileUpload from '@/components/molecules/FileUpload/FileUpload.astro';
 import NumberInput from '@/components/molecules/NumberInput/NumberInput.astro';
@@ -163,7 +164,6 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                         <th>Offer End Price</th>
                                         <th>Purchase Price</th>
                                         <th>Shares</th>
-                                        <th>Discount Amount</th>
                                         <th>Total Gain/Loss</th>
                                         <th>Disqualifying Disposition w/ STCG Taxes</th>
                                         <th>Disqualifying Disposition w/ LTCG Taxes</th>
@@ -174,7 +174,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                 <tbody>
                                     <template x-if="data.isLoadingESPPLots">
                                         <tr>
-                                            <td colspan="11">
+                                            <td colspan="10">
                                                 <progress class="progress is-primary">
                                                     Loading...
                                                 </progress>
@@ -183,11 +183,12 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                     </template>
                                     <template
                                         x-if="
-                                            !data.isLoadingESPPLots && data.purchases.length === 0
+                                            !data.isLoadingESPPLots
+                                            && data.displayPurchases.length === 0
                                         "
                                     >
                                         <tr>
-                                            <td colspan="11">
+                                            <td colspan="10">
                                                 <div class="has-text-centered">
                                                     No ESPP purchases found.
                                                 </div>
@@ -196,60 +197,42 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                     </template>
                                     <template
                                         x-if="
-                                            !data.isLoadingESPPLots && data.purchases.length !== 0
+                                            !data.isLoadingESPPLots
+                                            && data.displayPurchases.length !== 0
                                         "
                                     >
                                         <template
-                                            x-for="(purchase, index) in data.purchases"
+                                            x-for="(purchase, index) in data.displayPurchases"
                                             :key="purchase.id"
                                         >
                                             <tr>
-                                                <td
-                                                    x-text="
-                                                        methods.formatDateYYYYMMDD(
-                                                            purchase.grantDate
-                                                        )
-                                                    "
-                                                ></td>
-                                                <td
-                                                    x-text="
-                                                        methods.formatDateYYYYMMDD(
-                                                            purchase.purchaseDate
-                                                        )
-                                                    "
-                                                ></td>
+                                                <td x-text="purchase.grantDate"></td>
+                                                <td x-text="purchase.purchaseDate"></td>
                                                 <td
                                                     class="has-text-right"
-                                                    x-text="
-                                                        methods.formatUSD(purchase.offerStartPrice)
-                                                    "
-                                                ></td>
+                                                    x-text="purchase.offerStartPrice"></td>
                                                 <td
                                                     class="has-text-right"
-                                                    x-text="
-                                                        methods.formatUSD(purchase.offerEndPrice)
-                                                    "
-                                                ></td>
+                                                    x-text="purchase.offerEndPrice"></td>
                                                 <td
                                                     class="has-text-right"
-                                                    x-text="
-                                                        methods.formatUSD(purchase.purchasePrice)
-                                                    "
-                                                ></td>
+                                                    x-text="purchase.purchasePrice"></td>
                                                 <td class="has-text-right" x-text="purchase.shares"
                                                 ></td>
-                                                <td
-                                                    class="has-text-right"
-                                                    x-text="
-                                                        methods.formatUSD(purchase.discountAmount)
-                                                    "
-                                                ></td>
-                                                <td
-                                                    class="has-text-right"
-                                                    x-text="
-                                                        methods.formatUSD(purchase.totalGain)
-                                                    "
-                                                ></td>
+                                                <td class="has-text-right">
+                                                    <span x-text="purchase.gains.total"></span>
+                                                    <div
+                                                        x-show="
+                                                            purchase.uiState.isDetailsOpen
+                                                            && purchase.gains.total
+                                                        "
+                                                    >
+                                                        <CellDetails
+                                                            lineItemsXFor="purchase.gains.details"
+                                                            totalXText="purchase.gains.total"
+                                                        />
+                                                    </div>
+                                                </td>
                                                 <td
                                                     class="has-text-right"
                                                     :class="
@@ -257,12 +240,26 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                     purchase.dispositions?.disqualifyingSTCG.outcome
                                                 ]
                                             "
-                                                    x-text="
-                                                methods.formatUSD(
-                                                    purchase.dispositions?.disqualifyingSTCG.taxes
-                                                )
-                                            "
-                                                ></td>
+                                                >
+                                                    <span
+                                                        x-text="
+                                                purchase.dispositions?.disqualifyingSTCG.taxes.total
+                                                        "
+                                                    ></span>
+                                                    {/* eslint-disable max-len */}
+                                                    <div
+                                                        x-show="
+                                                            purchase.uiState.isDetailsOpen
+                                                            && purchase.dispositions?.disqualifyingSTCG.taxes.total
+                                                        "
+                                                    >
+                                                        <CellDetails
+                                                            lineItemsXFor="purchase.dispositions?.disqualifyingSTCG.taxes.details"
+                                                            totalXText="purchase.dispositions?.disqualifyingSTCG.taxes.total"
+                                                        />
+                                                    </div>
+                                                    {/* eslint-enable max-len */}
+                                                </td>
                                                 <td
                                                     class="has-text-right"
                                                     :class="
@@ -270,12 +267,26 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                     purchase.dispositions?.disqualifyingLTCG.outcome
                                                 ]
                                             "
-                                                    x-text="
-                                                methods.formatUSD(
-                                                    purchase.dispositions?.disqualifyingLTCG.taxes
-                                                )
-                                            "
-                                                ></td>
+                                                >
+                                                    <span
+                                                        x-text="
+                                                purchase.dispositions?.disqualifyingLTCG.taxes.total
+                                                        "
+                                                    ></span>
+                                                    {/* eslint-disable max-len */}
+                                                    <div
+                                                        x-show="
+                                                            purchase.uiState.isDetailsOpen
+                                                            && purchase.dispositions?.disqualifyingLTCG.taxes.total
+                                                        "
+                                                    >
+                                                        <CellDetails
+                                                            lineItemsXFor="purchase.dispositions?.disqualifyingLTCG.taxes.details"
+                                                            totalXText="purchase.dispositions?.disqualifyingLTCG.taxes.total"
+                                                        />
+                                                    </div>
+                                                    {/* eslint-enable max-len */}
+                                                </td>
                                                 <td
                                                     class="has-text-right"
                                                     :class="
@@ -283,12 +294,26 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                         purchase.dispositions?.qualifying.outcome
                                                     ]
                                                 "
-                                                    x-text="
-                                                    methods.formatUSD(
-                                                        purchase.dispositions?.qualifying.taxes
-                                                    )
-                                                "
-                                                ></td>
+                                                >
+                                                    <span
+                                                        x-text="
+                                                    purchase.dispositions?.qualifying.taxes.total
+                                                        "
+                                                    ></span>
+                                                    {/* eslint-disable max-len */}
+                                                    <div
+                                                        x-show="
+                                                            purchase.uiState.isDetailsOpen
+                                                            && purchase.dispositions?.qualifying.taxes.total
+                                                        "
+                                                    >
+                                                        <CellDetails
+                                                            lineItemsXFor="purchase.dispositions?.qualifying.taxes.details"
+                                                            totalXText="purchase.dispositions?.qualifying.taxes.total"
+                                                        />
+                                                    </div>
+                                                    {/* eslint-enable max-len */}
+                                                </td>
                                                 <td class="has-text-centered is-vcentered">
                                                     <div
                                                         class="dropdown is-right"
@@ -296,7 +321,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                             {
                                                                 'is-up':
                                                                     methods.isLastElement(
-                                                                        data.purchases,
+                                                                        data.displayPurchases,
                                                                         index
                                                                     ),
                                                                 'is-active':
@@ -324,9 +349,28 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                         <div class="dropdown-menu" role="menu">
                                                             <div class="dropdown-content">
                                                                 <a
-                                                                    class="button
-                                                                        is-ghost
-                                                                        dropdown-item
+                                                                    class="has-text-info
+                                                                        dropdown-item"
+                                                                    @click.stop="
+                                                                        methods.toggleDetails
+                                                                    "
+                                                                    :data-purchase-id="
+                                                                            purchase.id
+                                                                        "
+                                                                >
+                                                                    <span
+                                                                        class="icon
+                                                                                is-small mr-1"
+                                                                    >
+                                                                        <i
+                                                                            class="fas
+                                                                                fa-info-circle"
+                                                                        ></i>
+                                                                    </span>
+                                                                    Details
+                                                                </a>
+                                                                <a
+                                                                    class="dropdown-item
                                                                         has-text-danger"
                                                                     :class="
                                                                         {
@@ -337,10 +381,13 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                                                     @click.stop="
                                                                         methods.deleteLot
                                                                     "
-                                                                    :data-purchase-id="purchase.id"
+                                                                    :data-purchase-id="
+                                                                            purchase.id
+                                                                        "
                                                                 >
                                                                     <span
-                                                                        class="icon is-small mr-1"
+                                                                        class="icon
+                                                                                is-small mr-1"
                                                                     >
                                                                         <i class="fas fa-trash"></i>
                                                                     </span>

--- a/frontend/test/utils/espp-calculations.spec.ts
+++ b/frontend/test/utils/espp-calculations.spec.ts
@@ -59,15 +59,21 @@ describe('espp-calculations', () => {
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
                 expect(testPurchase.marketGain).toBe(0);
-                expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(1145.62, 2);
+                expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
+                    1145.62,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BETTER,
                 );
-                expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(1145.62, 2);
+                expect(testPurchase.dispositions.disqualifyingLTCG.taxes.total).toBeCloseTo(
+                    1145.62,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(
                     ESPPTaxOutcome.BETTER,
                 );
-                expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(824.33, 2);
+                expect(testPurchase.dispositions.qualifying.taxes.total).toBeCloseTo(824.33, 2);
                 expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
             },
         );
@@ -90,15 +96,21 @@ describe('espp-calculations', () => {
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
                 expect(testPurchase.marketGain).toBeCloseTo(482.65, 2);
-                expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(1261.46, 2);
+                expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
+                    1261.46,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.GOOD,
                 );
-                expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(1218.02, 2);
+                expect(testPurchase.dispositions.disqualifyingLTCG.taxes.total).toBeCloseTo(
+                    1218.02,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(
                     ESPPTaxOutcome.BETTER,
                 );
-                expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(896.73, 2);
+                expect(testPurchase.dispositions.qualifying.taxes.total).toBeCloseTo(896.73, 2);
                 expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
             },
         );
@@ -121,15 +133,21 @@ describe('espp-calculations', () => {
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
                 expect(testPurchase.marketGain).toBeCloseTo(-965.3, 2);
-                expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(913.95, 2);
+                expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
+                    913.95,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BETTER,
                 );
-                expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(913.95, 2);
+                expect(testPurchase.dispositions.disqualifyingLTCG.taxes.total).toBeCloseTo(
+                    913.95,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(
                     ESPPTaxOutcome.BETTER,
                 );
-                expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(679.54, 2);
+                expect(testPurchase.dispositions.qualifying.taxes.total).toBeCloseTo(679.54, 2);
                 expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
             },
         );
@@ -152,15 +170,21 @@ describe('espp-calculations', () => {
                 expect(testPurchase.purchaseMarketPrice).toBe(marketPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
                 expect(testPurchase.marketGain).toBe(0);
-                expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(342.38, 2);
+                expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
+                    342.38,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BEST,
                 );
-                expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(342.38, 2);
+                expect(testPurchase.dispositions.disqualifyingLTCG.taxes.total).toBeCloseTo(
+                    342.38,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(
                     ESPPTaxOutcome.BEST,
                 );
-                expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(342.38, 2);
+                expect(testPurchase.dispositions.qualifying.taxes.total).toBeCloseTo(342.38, 2);
                 expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
             },
         );
@@ -183,15 +207,21 @@ describe('espp-calculations', () => {
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
                 expect(testPurchase.marketGain).toBeCloseTo(977.02, 2);
-                expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(576.86, 2);
+                expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
+                    576.86,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.GOOD,
                 );
-                expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(488.93, 2);
+                expect(testPurchase.dispositions.disqualifyingLTCG.taxes.total).toBeCloseTo(
+                    488.93,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(
                     ESPPTaxOutcome.BEST,
                 );
-                expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(540.85, 2);
+                expect(testPurchase.dispositions.qualifying.taxes.total).toBeCloseTo(540.85, 2);
                 expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BETTER);
             },
         );
@@ -214,15 +244,21 @@ describe('espp-calculations', () => {
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
                 expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
                 expect(testPurchase.marketGain).toBeCloseTo(-749.25, 2);
-                expect(testPurchase.dispositions.disqualifyingSTCG.taxes).toBeCloseTo(162.56, 2);
+                expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
+                    162.56,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingSTCG.outcome).toBe(
                     ESPPTaxOutcome.BEST,
                 );
-                expect(testPurchase.dispositions.disqualifyingLTCG.taxes).toBeCloseTo(162.56, 2);
+                expect(testPurchase.dispositions.disqualifyingLTCG.taxes.total).toBeCloseTo(
+                    162.56,
+                    2,
+                );
                 expect(testPurchase.dispositions.disqualifyingLTCG.outcome).toBe(
                     ESPPTaxOutcome.BEST,
                 );
-                expect(testPurchase.dispositions.qualifying.taxes).toBeCloseTo(162.56, 2);
+                expect(testPurchase.dispositions.qualifying.taxes.total).toBeCloseTo(162.56, 2);
                 expect(testPurchase.dispositions.qualifying.outcome).toBe(ESPPTaxOutcome.BEST);
             },
         );


### PR DESCRIPTION
<img width="1432" height="452" alt="image" src="https://github.com/user-attachments/assets/29e80b87-0562-4ce5-b711-a182e79d6542" />

### What

Add details to gains and taxes cells in ESPP table

### How

- Add cell details component
- Create espp UI utils for code that doesn't interface directly with the UI
- Create display ESPP purchase interfaces to reduce in template function calls
- Add gains breakdowns and taxes breakdowns in ESPP calculations

### Validation

- Unit test coverage 54%