### PR TITLE
Fix bug where 0 total gain wasn't displayed

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.13.0",
+            "version": "0.13.1",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.7",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu",
     "type": "module",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",

--- a/frontend/src/pages/work/_espp.utils.ts
+++ b/frontend/src/pages/work/_espp.utils.ts
@@ -14,7 +14,7 @@ interface ESPPDetailsUI {
     amount: string;
 }
 
-interface ESSPGainsUI {
+interface ESPPGainsUI {
     discountAmount: string;
     market: string | undefined;
     total: string | undefined;
@@ -54,7 +54,7 @@ interface ESPPPurchaseTaxesUI {
     offerEndPrice: string;
     purchasePrice: string;
     shares: string;
-    gains: ESSPGainsUI;
+    gains: ESPPGainsUI;
     dispositions: ESPPDispositionsUI | undefined;
     uiState: ESPPPurchaseUIState;
 }
@@ -87,11 +87,11 @@ function convertEsppTaxesToUIState(purchasesTaxes: ESPPPurchaseTaxes[]): ESPPPur
 export { convertEsppTaxesToUIState };
 export type { ESPPPurchaseTaxesUI };
 
-function convertGainsToUI(purchase: ESPPPurchaseTaxes): ESSPGainsUI {
+function convertGainsToUI(purchase: ESPPPurchaseTaxes): ESPPGainsUI {
     return {
         discountAmount: formatUSD(purchase.discountAmount),
-        market: purchase.marketGain ? formatUSD(purchase.marketGain) : undefined,
-        total: purchase.totalGain ? formatUSD(purchase.totalGain) : undefined,
+        market: purchase.marketGain !== undefined ? formatUSD(purchase.marketGain) : undefined,
+        total: purchase.totalGain !== undefined ? formatUSD(purchase.totalGain) : undefined,
         details: _convertGainsToDetailsUI(purchase),
     };
 }

--- a/frontend/src/utils/number.ts
+++ b/frontend/src/utils/number.ts
@@ -5,7 +5,7 @@ function formatUSD(value: number): string {
 
     const displayValue = Math.abs(value).toFixed(2);
 
-    if (value > 0) {
+    if (value >= 0) {
         return `$${displayValue}`;
     }
 

--- a/frontend/test/utils/number.spec.ts
+++ b/frontend/test/utils/number.spec.ts
@@ -10,6 +10,12 @@ describe('number', () => {
             expect(formattedValue).toBe('$1234.56');
         });
 
+        test('should format zero to USD', () => {
+            const value = 0;
+            const formattedValue = formatUSD(value);
+            expect(formattedValue).toBe('$0.00');
+        });
+
         test('should format negative number to USD', () => {
             const value = -1234.5611;
             const formattedValue = formatUSD(value);


### PR DESCRIPTION
<img width="1616" height="178" alt="image" src="https://github.com/user-attachments/assets/0ab7a73a-9e63-4d2a-9620-b1903171a1c4" />

### What

Fix bug where 0 total gain wasn't displayed

### How

- Only skip number to USD formatting when undefined
- Format 0 as positive
- Fix interface typo

### Validation

- Unit test coverage 54%

Fixes #35 