### PR TITLE
Add support for ESPP sales calculations

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.13.2",
+    "version": "0.14.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.13.2",
+            "version": "0.14.0",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.7",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu",
     "type": "module",
-    "version": "0.13.2",
+    "version": "0.14.0",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",

--- a/frontend/src/components/organisms/ESPPSalesTable/ESPPSalesTable.astro
+++ b/frontend/src/components/organisms/ESPPSalesTable/ESPPSalesTable.astro
@@ -1,0 +1,66 @@
+---
+import CellDetails from '@/components/molecules/CellDetails/CellDetails.astro';
+
+interface Props {
+    salesXFor: Array<ESPPSales>;
+}
+
+const { salesXFor } = Astro.props;
+---
+
+<div class="table-container">
+    <table class="table is-hoverable">
+        <thead>
+            <tr>
+                <th>Purchase Date</th>
+                <th>Sale Date</th>
+                <th>Purchase Price</th>
+                <th>Sale Price</th>
+                <th>Sold Shares</th>
+                <th>Gains</th>
+                <th>Disposition</th>
+                <th>Taxes</th>
+            </tr>
+        </thead>
+        <tbody>
+            <template x-if={`${salesXFor}.length === 0`}>
+                <tr>
+                    <td colspan="8">
+                        <div class="has-text-centered">
+                            No ESPP sales found.
+                        </div>
+                    </td>
+                </tr>
+            </template>
+            <template x-for={`sale in ${salesXFor}`} :key="sale.id">
+                <tr>
+                    <td x-text="sale.purchase.purchaseDate"></td>
+                    <td x-text="sale.date"></td>
+                    <td class="has-text-right" x-text="sale.purchase.purchasePrice"></td>
+                    <td class="has-text-right" x-text="sale.price"></td>
+                    <td class="has-text-right" x-text="sale.shares"></td>
+                    <td class="has-text-right">
+                        <span x-text="sale.gains.total"></span>
+                        <div x-show="sale.uiState.isDetailsOpen && sale.gains.total">
+                            <CellDetails
+                                lineItemsXFor="sale.gains.details"
+                                totalXText="sale.gains.total"
+                            />
+                        </div>
+                    </td>
+                    <td x-text="sale.disposition.name"></td>
+                    <td class="has-text-right">
+                        <span x-text="sale.disposition.taxes.total"></span>
+                        <div x-show="sale.uiState.isDetailsOpen && sale.disposition.taxes.total">
+                            <CellDetails
+                                lineItemsXFor="sale.disposition.taxes.details"
+                                totalXText="sale.disposition.taxes.total"
+                            />
+                        </div>
+                    </td>
+                </tr>
+            </template>
+        </tbody>
+    </table>
+</div>
+<script src="./espp-sales-table.client.ts"></script>

--- a/frontend/src/components/organisms/ESPPSalesTable/espp-sales-table.client.ts
+++ b/frontend/src/components/organisms/ESPPSalesTable/espp-sales-table.client.ts
@@ -1,0 +1,14 @@
+import Alpine from 'alpinejs';
+
+import type { XData } from '@/domain/components/x-data';
+
+type ESPPSalesTableXData = XData<{}, {}>;
+
+function esppSalesTableXData(): ESPPSalesTableXData {
+    return {
+        data: {},
+        methods: {},
+    };
+}
+
+Alpine.data('esppSalesTableXData', esppSalesTableXData);

--- a/frontend/src/domain/espp/espp-disposition-name.ts
+++ b/frontend/src/domain/espp/espp-disposition-name.ts
@@ -1,0 +1,7 @@
+enum ESPPDispositionName {
+    DISQUALIFYING_STCG = 'Disqualifying Disposition w/ STCG',
+    DISQUALIFYING_LTCG = 'Disqualifying Disposition w/ LTCG',
+    QUALIFYING = 'Qualifying Disposition',
+}
+
+export { ESPPDispositionName };

--- a/frontend/src/domain/espp/espp-purchase-parsed.ts
+++ b/frontend/src/domain/espp/espp-purchase-parsed.ts
@@ -1,0 +1,19 @@
+interface ESPPSale {
+    id: string;
+    date: Date;
+    price: number;
+    shares: number;
+}
+
+interface ESPPPurchase {
+    id: string;
+    grantDate: Date;
+    purchaseDate: Date;
+    offerStartPrice: number;
+    offerEndPrice: number;
+    purchasePrice: number;
+    shares: number;
+    sales: ESPPSale[];
+}
+
+export type { ESPPPurchase, ESPPSale };

--- a/frontend/src/pages/work/espp.astro
+++ b/frontend/src/pages/work/espp.astro
@@ -3,6 +3,7 @@ import CellDetails from '@/components/molecules/CellDetails/CellDetails.astro';
 import DateInput from '@/components/molecules/DateInput/DateInput.astro';
 import FileUpload from '@/components/molecules/FileUpload/FileUpload.astro';
 import NumberInput from '@/components/molecules/NumberInput/NumberInput.astro';
+import ESPPSalesTable from '@/components/organisms/ESPPSalesTable/ESPPSalesTable.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 ---
 
@@ -403,6 +404,12 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                                 </tbody>
                             </table>
                         </div>
+                    </div>
+                </div>
+                <div class="block" x-cloak x-show="methods.showTaxConsiderations" x-transition>
+                    <div class="box">
+                        <h2 class="title is-2">Sold ESPP Lots</h2>
+                        <ESPPSalesTable salesXFor="data.displaySales" />
                     </div>
                 </div>
             </div>

--- a/frontend/test/utils/espp-calculations.spec.ts
+++ b/frontend/test/utils/espp-calculations.spec.ts
@@ -45,7 +45,7 @@ describe('espp-calculations', () => {
             'should calculate cases where offering start price is less than offering end price' +
                 ' and market price is flat',
             async () => {
-                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES);
+                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES).purchases;
                 const testPurchase = guardPurchaseTaxTestObject(purchasesTaxes[0]);
 
                 const marketPrice = testPurchase.offerEndPrice;
@@ -57,8 +57,8 @@ describe('espp-calculations', () => {
                 }
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
-                expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
-                expect(testPurchase.marketGain).toBe(0);
+                expect(testPurchase.gains.discountAmount).toBeCloseTo(4773.42, 2);
+                expect(testPurchase.gains.market).toBe(0);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
                     1145.62,
                     2,
@@ -82,7 +82,7 @@ describe('espp-calculations', () => {
             'should calculate cases where offering start price is less than offering end price' +
                 ' and market price is up',
             async () => {
-                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES);
+                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES).purchases;
                 const testPurchase = guardPurchaseTaxTestObject(purchasesTaxes[0]);
 
                 const marketPrice = testPurchase.offerEndPrice + 5;
@@ -94,8 +94,8 @@ describe('espp-calculations', () => {
                 }
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
-                expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
-                expect(testPurchase.marketGain).toBeCloseTo(482.65, 2);
+                expect(testPurchase.gains.discountAmount).toBeCloseTo(4773.42, 2);
+                expect(testPurchase.gains.market).toBeCloseTo(482.65, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
                     1261.46,
                     2,
@@ -119,7 +119,7 @@ describe('espp-calculations', () => {
             'should calculate cases where offering start price is less than offering end price' +
                 ' and market price is down',
             async () => {
-                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES);
+                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES).purchases;
                 const testPurchase = guardPurchaseTaxTestObject(purchasesTaxes[0]);
 
                 const marketPrice = testPurchase.offerEndPrice - 10;
@@ -131,8 +131,8 @@ describe('espp-calculations', () => {
                 }
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerStartPrice);
-                expect(testPurchase.discountAmount).toBeCloseTo(4773.42, 2);
-                expect(testPurchase.marketGain).toBeCloseTo(-965.3, 2);
+                expect(testPurchase.gains.discountAmount).toBeCloseTo(4773.42, 2);
+                expect(testPurchase.gains.market).toBeCloseTo(-965.3, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
                     913.95,
                     2,
@@ -156,7 +156,7 @@ describe('espp-calculations', () => {
             'should calculate cases where offering start price is greater than offering end price' +
                 ' and market price is flat',
             async () => {
-                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES);
+                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES).purchases;
                 const testPurchase = guardPurchaseTaxTestObject(purchasesTaxes[1]);
 
                 const marketPrice = testPurchase.offerEndPrice;
@@ -168,8 +168,8 @@ describe('espp-calculations', () => {
                 }
 
                 expect(testPurchase.purchaseMarketPrice).toBe(marketPrice);
-                expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
-                expect(testPurchase.marketGain).toBe(0);
+                expect(testPurchase.gains.discountAmount).toBeCloseTo(1426.57, 2);
+                expect(testPurchase.gains.market).toBe(0);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
                     342.38,
                     2,
@@ -193,7 +193,7 @@ describe('espp-calculations', () => {
             'should calculate cases where offering start price is greater than offering end price' +
                 ' and market price is up',
             () => {
-                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES);
+                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES).purchases;
                 const testPurchase = guardPurchaseTaxTestObject(purchasesTaxes[1]);
 
                 const marketPrice = 70.0;
@@ -205,8 +205,8 @@ describe('espp-calculations', () => {
                 }
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
-                expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
-                expect(testPurchase.marketGain).toBeCloseTo(977.02, 2);
+                expect(testPurchase.gains.discountAmount).toBeCloseTo(1426.57, 2);
+                expect(testPurchase.gains.market).toBeCloseTo(977.02, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
                     576.86,
                     2,
@@ -230,7 +230,7 @@ describe('espp-calculations', () => {
             'should calculate cases where offering start price is greater than offering end price' +
                 ' and market price is down',
             () => {
-                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES);
+                const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES).purchases;
                 const testPurchase = guardPurchaseTaxTestObject(purchasesTaxes[1]);
 
                 const marketPrice = testPurchase.offerEndPrice - 5;
@@ -242,8 +242,8 @@ describe('espp-calculations', () => {
                 }
 
                 expect(testPurchase.purchaseMarketPrice).toBe(testPurchase.offerEndPrice);
-                expect(testPurchase.discountAmount).toBeCloseTo(1426.57, 2);
-                expect(testPurchase.marketGain).toBeCloseTo(-749.25, 2);
+                expect(testPurchase.gains.discountAmount).toBeCloseTo(1426.57, 2);
+                expect(testPurchase.gains.market).toBeCloseTo(-749.25, 2);
                 expect(testPurchase.dispositions.disqualifyingSTCG.taxes.total).toBeCloseTo(
                     162.56,
                     2,
@@ -266,17 +266,17 @@ describe('espp-calculations', () => {
 
     describe('clearMarketDependentValues', () => {
         test('should clear market dependent values', () => {
-            const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES);
+            const purchasesTaxes = loadESPPPurchasesTaxes(MOCK_ESPP_PURCHASES).purchases;
             const testPurchase = guardPurchaseTaxTestObject(purchasesTaxes[0]);
 
             updateMarketDependentValues(purchasesTaxes, 100);
 
-            expect(testPurchase.marketGain).toBeDefined();
+            expect(testPurchase.gains.market).toBeDefined();
             expect(testPurchase.dispositions).toBeDefined();
 
             clearMarketDependentValues(purchasesTaxes);
 
-            expect(testPurchase.marketGain).toBeUndefined();
+            expect(testPurchase.gains.market).toBeUndefined();
             expect(testPurchase.dispositions).toBeUndefined();
         });
     });


### PR DESCRIPTION
<img width="1966" height="478" alt="image" src="https://github.com/user-attachments/assets/a27d2aac-9a76-47ca-99fa-4c6f8b79b9f7" />

### What

Add support for ESPP Sale calculations. Currently there are no sales in the database so no sales will appear in the UI

### How

- Create ESPP Sales table
  - Use component to keep main page cleaner
- Parse purchases and sales from API response
  - Calculate gains, disposition, and taxes for sale
- Organize gains into sub object

### Validation

- Unit tests pass
- ESPP Purchases table unaffected