### PR TITLE
Add breakdown after 401k calculation

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -20,7 +20,13 @@ export default [
             'comma-dangle': ['error', 'always-multiline'],
             indent: ['error', 4],
             'no-unused-vars': 'off',
-            'max-len': ['error', { code: 100 }],
+            'max-len': [
+                'error',
+                {
+                    code: 100,
+                    ignorePattern: '^import\\s.+\\sfrom\\s.+;$',
+                },
+            ],
             'import/order': [
                 'error',
                 {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fife",
-    "version": "0.14.1",
+    "version": "0.15.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fife",
-            "version": "0.14.1",
+            "version": "0.15.0",
             "dependencies": {
                 "@astrojs/alpinejs": "^0.4.7",
                 "@fortawesome/fontawesome-free": "^6.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fife",
     "description": "Finance for Everyone",
-    "author": "Luke Hurst <hurstlj@umich.edu",
+    "author": "Luke Hurst <hurstlj@umich.edu>",
     "type": "module",
     "version": "0.14.1",
     "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "description": "Finance for Everyone",
     "author": "Luke Hurst <hurstlj@umich.edu>",
     "type": "module",
-    "version": "0.14.1",
+    "version": "0.15.0",
     "scripts": {
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"test/**/*.ts\"",

--- a/frontend/src/components/molecules/CalculationBreakdown/CalculationBreakdown.astro
+++ b/frontend/src/components/molecules/CalculationBreakdown/CalculationBreakdown.astro
@@ -1,0 +1,30 @@
+---
+interface Props {
+    itemsXFor: string;
+    resultLabel?: string;
+    resultXText?: string;
+}
+
+const { itemsXFor, resultLabel, resultXText } = Astro.props;
+---
+
+<div
+    class="has-background-primary-dark has-text-primary-dark-invert
+        p-3 is-size-7 has-text-right mt-3"
+    style="border-radius: 4px;"
+>
+    <template x-for={`item in ${itemsXFor}`}>
+        <div class="mb-2">
+            <span class="has-text-weight-normal" x-text="item.label + ':'"></span>
+            <span class="ml-2 has-text-weight-semibold" x-text="item.value"></span>
+        </div>
+    </template>
+    {
+        resultLabel && resultXText && (
+            <div class="mt-3 pt-3" style="border-top: 1px dashed;">
+                <span class="has-text-weight-bold">{resultLabel}:</span>
+                <span class="ml-2 has-text-weight-bold" x-text={resultXText} />
+            </div>
+        )
+    }
+</div>

--- a/frontend/src/pages/work/401k.astro
+++ b/frontend/src/pages/work/401k.astro
@@ -95,11 +95,18 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 
                         <div x-show="data.isDetailsOpen" x-transition x-cloak>
                             <template x-if="data.breakdownItems.length > 0">
-                                <CalculationBreakdown
-                                    itemsXFor="data.breakdownItems"
-                                    resultLabel="Total Contributions (with ceil)"
-                                    resultXText="data.breakdownTotal"
-                                />
+                                <div class="field is-horizontal">
+                                    <div class="field-label is-normal"></div>
+                                    <div class="field-body">
+                                        <div class="field is-narrow">
+                                            <CalculationBreakdown
+                                                itemsXFor="data.breakdownItems"
+                                                resultLabel="Total Contributions (with ceil)"
+                                                resultXText="data.breakdownTotal"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
                             </template>
                         </div>
                     </div>

--- a/frontend/src/pages/work/401k.astro
+++ b/frontend/src/pages/work/401k.astro
@@ -1,4 +1,5 @@
 ---
+import CalculationBreakdown from '@/components/molecules/CalculationBreakdown/CalculationBreakdown.astro';
 import NumberInput from '@/components/molecules/NumberInput/NumberInput.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 ---
@@ -70,6 +71,37 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                             value="data.ceilContributionPercent"
                             readonly="true"
                         />
+
+                        <div class="mt-4">
+                            <a
+                                class="is-size-7 has-text-info"
+                                style="cursor: pointer;"
+                                @click="methods.toggleDetails"
+                            >
+                                <span class="icon is-small">
+                                    <i
+                                        class="fas"
+                                        :class="
+                                            data.isDetailsOpen ?
+                                            'fa-chevron-up' :
+                                            'fa-chevron-down'
+                                        "
+                                    ></i>
+                                </span>
+                                <span x-text="data.isDetailsOpen ? 'Hide Details' : 'Show Details'">
+                                </span>
+                            </a>
+                        </div>
+
+                        <div x-show="data.isDetailsOpen" x-transition x-cloak>
+                            <template x-if="data.breakdownItems.length > 0">
+                                <CalculationBreakdown
+                                    itemsXFor="data.breakdownItems"
+                                    resultLabel="Total Contributions (with ceil)"
+                                    resultXText="data.breakdownTotal"
+                                />
+                            </template>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/frontend/src/pages/work/_401k.client.ts
+++ b/frontend/src/pages/work/_401k.client.ts
@@ -4,9 +4,17 @@ import type { XData } from '@/domain/components/x-data';
 import {
     isMaximize401kInputsReady,
     calculate401kContributionPercent,
+    calculate401kBreakdown,
+    type Maximize401kBreakdown,
 } from '@/utils/401k-calculations';
 import { register } from '@/utils/alpine-components';
 import { getCurrentUser } from '@/utils/auth';
+import { formatUSD } from '@/utils/number';
+
+interface BreakdownItem {
+    label: string;
+    value: string;
+}
 
 type Maximize401kXData = XData<
     {
@@ -16,11 +24,16 @@ type Maximize401kXData = XData<
         paychecksPerYear: number | null;
         paychecksRemaining: string | null;
         ceilContributionPercent: number | null;
+        isDetailsOpen: boolean;
+        breakdownDetails: Maximize401kBreakdown | null;
+        breakdownItems: BreakdownItem[];
+        breakdownTotal: string;
     },
     {
         init: () => Promise<void>;
         showMaximize401k: () => boolean;
         on401kDetailsInput: () => void;
+        toggleDetails: () => void;
     }
 >;
 
@@ -33,6 +46,10 @@ function maximize401kXData(): Maximize401kXData {
             paychecksPerYear: null,
             paychecksRemaining: null,
             ceilContributionPercent: null,
+            isDetailsOpen: false,
+            breakdownDetails: null,
+            breakdownItems: [],
+            breakdownTotal: '',
         },
         methods: {
             async init(this: Maximize401kXData): Promise<void> {
@@ -63,11 +80,39 @@ function maximize401kXData(): Maximize401kXData {
 
                 if (!isMaximize401kInputsReady(input)) {
                     this.data.ceilContributionPercent = null;
+                    this.data.breakdownDetails = null;
+                    this.data.breakdownItems = [];
+                    this.data.breakdownTotal = '';
                     return;
                 }
 
                 const contributionPercent = calculate401kContributionPercent(input);
                 this.data.ceilContributionPercent = Math.ceil(contributionPercent);
+
+                const breakdown = calculate401kBreakdown(input);
+                this.data.breakdownDetails = breakdown;
+                this.data.breakdownItems = [
+                    {
+                        label: 'Remaining Contribution',
+                        value: formatUSD(breakdown.remainingContribution),
+                    },
+                    {
+                        label: 'Salary Per Paycheck',
+                        value: formatUSD(breakdown.salaryPerPaycheck),
+                    },
+                    {
+                        label: 'Contribution Per Paycheck',
+                        value: formatUSD(breakdown.contributionPerPaycheck),
+                    },
+                    {
+                        label: 'Raw Percentage',
+                        value: breakdown.rawPercentage.toFixed(2) + '%',
+                    },
+                ];
+                this.data.breakdownTotal = formatUSD(breakdown.totalWithCeiledPercent);
+            },
+            toggleDetails(this: Maximize401kXData): void {
+                this.data.isDetailsOpen = !this.data.isDetailsOpen;
             },
         },
     };
@@ -75,12 +120,21 @@ function maximize401kXData(): Maximize401kXData {
 
 register('maximize401kXData', maximize401kXData);
 
-function parseInputs(inputs: Record<string, string | number | null>): Maximize401kInput {
+function parseInputs(
+    inputs: Pick<
+        Maximize401kXData['data'],
+        | 'annualSalary'
+        | 'annualContributionLimit'
+        | 'contributionsSoFar'
+        | 'paychecksPerYear'
+        | 'paychecksRemaining'
+    >,
+): Maximize401kInput {
     return {
         annualSalary: parseFloat(inputs.annualSalary as string),
         annualContributionLimit: parseInt(inputs.annualContributionLimit as string),
         contributionsSoFar: parseFloat(inputs.contributionsSoFar as string),
-        paychecksPerYear: parseInt(inputs.paychecksPerYear as string),
+        paychecksPerYear: inputs.paychecksPerYear as number,
         paychecksRemaining: parseInt(inputs.paychecksRemaining as string),
     };
 }

--- a/frontend/src/utils/401k-calculations.ts
+++ b/frontend/src/utils/401k-calculations.ts
@@ -1,5 +1,14 @@
 import type { Maximize401kInput } from '@/domain/401k/maximize-401k-input';
 
+interface Maximize401kBreakdown {
+    remainingContribution: number;
+    contributionPerPaycheck: number;
+    salaryPerPaycheck: number;
+    rawPercentage: number;
+    ceiledPercentage: number;
+    totalWithCeiledPercent: number;
+}
+
 function isMaximize401kInputsReady(input: Maximize401kInput): boolean {
     for (const key in input) {
         if (Number.isNaN(input[key as keyof Maximize401kInput])) {
@@ -29,4 +38,32 @@ function calculate401kContributionPercent(input: Maximize401kInput): number {
     return contributionDecimal * 100;
 }
 
-export { isMaximize401kInputsReady, calculate401kContributionPercent };
+function calculate401kBreakdown(input: Maximize401kInput): Maximize401kBreakdown {
+    const {
+        annualSalary,
+        annualContributionLimit,
+        contributionsSoFar,
+        paychecksPerYear,
+        paychecksRemaining,
+    } = input;
+
+    const remainingContribution = annualContributionLimit - contributionsSoFar;
+    const contributionPerPaycheck = remainingContribution / paychecksRemaining;
+    const salaryPerPaycheck = annualSalary / paychecksPerYear;
+    const rawPercentage = (contributionPerPaycheck / salaryPerPaycheck) * 100;
+    const ceiledPercentage = Math.ceil(rawPercentage);
+    const totalWithCeiledPercent =
+        contributionsSoFar + (ceiledPercentage / 100) * salaryPerPaycheck * paychecksRemaining;
+
+    return {
+        remainingContribution,
+        contributionPerPaycheck,
+        salaryPerPaycheck,
+        rawPercentage,
+        ceiledPercentage,
+        totalWithCeiledPercent,
+    };
+}
+
+export { isMaximize401kInputsReady, calculate401kContributionPercent, calculate401kBreakdown };
+export type { Maximize401kBreakdown };

--- a/frontend/src/utils/number.ts
+++ b/frontend/src/utils/number.ts
@@ -3,7 +3,10 @@ function formatUSD(value: number): string {
         return '';
     }
 
-    const displayValue = Math.abs(value).toFixed(2);
+    const displayValue = Math.abs(value).toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
 
     if (value >= 0) {
         return `$${displayValue}`;

--- a/frontend/test/utils/401k-calculations.spec.ts
+++ b/frontend/test/utils/401k-calculations.spec.ts
@@ -3,6 +3,7 @@ import { describe, test, expect } from 'vitest';
 import {
     isMaximize401kInputsReady,
     calculate401kContributionPercent,
+    calculate401kBreakdown,
 } from '@/utils/401k-calculations';
 
 describe('401k-calculations', () => {
@@ -48,5 +49,41 @@ describe('401k-calculations', () => {
                 expect(calculate401kContributionPercent(input)).toBeCloseTo(62.83, 2);
             },
         );
+    });
+
+    describe('calculate401kBreakdown', () => {
+        test('should calculate all breakdown values correctly', () => {
+            const input = {
+                annualSalary: 60000,
+                annualContributionLimit: 19500,
+                contributionsSoFar: 5000,
+                paychecksPerYear: 26,
+                paychecksRemaining: 10,
+            };
+
+            const breakdown = calculate401kBreakdown(input);
+
+            expect(breakdown.remainingContribution).toBe(14500);
+            expect(breakdown.contributionPerPaycheck).toBe(1450);
+            expect(breakdown.salaryPerPaycheck).toBeCloseTo(2307.69, 2);
+            expect(breakdown.rawPercentage).toBeCloseTo(62.83, 2);
+            expect(breakdown.ceiledPercentage).toBe(63);
+            expect(breakdown.totalWithCeiledPercent).toBeCloseTo(19538.46, 2);
+        });
+
+        test('should handle edge case with no remaining paychecks', () => {
+            const input = {
+                annualSalary: 60000,
+                annualContributionLimit: 19500,
+                contributionsSoFar: 5000,
+                paychecksPerYear: 26,
+                paychecksRemaining: 1,
+            };
+
+            const breakdown = calculate401kBreakdown(input);
+
+            expect(breakdown.remainingContribution).toBe(14500);
+            expect(breakdown.contributionPerPaycheck).toBe(14500);
+        });
     });
 });

--- a/frontend/test/utils/number.spec.ts
+++ b/frontend/test/utils/number.spec.ts
@@ -4,10 +4,10 @@ import { formatUSD, round } from '@/utils/number';
 
 describe('number', () => {
     describe('formatUSD', () => {
-        test('should format positive number to USD', () => {
+        test('should format positive number to USD with commas', () => {
             const value = 1234.5611;
             const formattedValue = formatUSD(value);
-            expect(formattedValue).toBe('$1234.56');
+            expect(formattedValue).toBe('$1,234.56');
         });
 
         test('should format zero to USD', () => {
@@ -16,10 +16,10 @@ describe('number', () => {
             expect(formattedValue).toBe('$0.00');
         });
 
-        test('should format negative number to USD', () => {
+        test('should format negative number to USD with commas', () => {
             const value = -1234.5611;
             const formattedValue = formatUSD(value);
-            expect(formattedValue).toBe('-$1234.56');
+            expect(formattedValue).toBe('-$1,234.56');
         });
 
         test('should format NaN to empty string', () => {


### PR DESCRIPTION
<img width="608" height="1046" alt="image" src="https://github.com/user-attachments/assets/504de2e2-b581-4da0-aa68-526be24aa477" />

### What

Add calculations breakdown to 401k maximization

### How

- Show math
- Show raw percent

### Validation

- Tests pass
- Ran locally